### PR TITLE
Add Option to Filter Events

### DIFF
--- a/app/assets/stylesheets/colors/variables.scss
+++ b/app/assets/stylesheets/colors/variables.scss
@@ -1,0 +1,20 @@
+// variables.scss
+
+$back-pass: #5100a2;
+$backgorund-btn: #259503;
+$backhover-btn: #046f00;
+$blue: #007bff;
+$border-pass: #212529;
+$button-color: #ac019e;
+$button-hover: #910196;
+$color-background: #f9f9f9;
+$color-border: #ccc;
+$color-highlight: #007bff;
+$color-text: #333;
+$hover-pass: #3c0364;
+$hover-reg: #046f00;
+$hoverbtn: #0056b3;
+$login-hover: #0056b3;
+$pasbtn: #b8a901;
+$reg-back: #259503;
+$white: #ffffff;

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -1,22 +1,107 @@
+@import "./colors/variables.scss";
+
 .beditar {
-  display: flex;
-  text-align: center;
-  background-color: #ac019e;
-  border-color: #ffffff;
-  color: #ffffff;
+  background-color: $button-color;
+  border-color: $white;
   border-radius: 5px;
+  color: $white;
   cursor: pointer;
-  text-decoration: none;
+  display: flex;
   padding: 4px 15px;
+  text-align: center;
+  text-decoration: none;
   transition: background-color 0.3s ease;
 }
 .beditar:hover {
-  background-color: #910196;
+  background-color: $button-hover;
 }
 
 .buttons {
-  justify-content: center;
-  gap: 10px;
   display: flex;
   flex-direction: row;
+  gap: 10px;
+  justify-content: center;
+}
+
+.search {
+  display: flex;
+  flex-direction: column;
+  margin: 15px;
+  padding: 5px;
+  position: absolute;
+}
+
+.search form {
+  margin: 10px;
+}
+
+.field {
+  background-color: $color-background;
+  border-radius: 5px;
+  border: 1px solid $color-border;
+  color: $color-text;
+  font-size: 16px;
+  padding: 8px 12px;
+  transition: border-color 0.3s ease-in-out;
+  width: 160px;
+
+  &:focus {
+    border-color: $color-highlight;
+    outline: none;
+  }
+
+  &::-webkit-calendar-picker-indicator {
+    filter: invert(0.8);
+  }
+  &::-webkit-calendar-picker-indicator {
+    background-color: $color-background;
+    border-radius: 5px;
+    border: none;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+    color: $color-text;
+    font-size: 16px;
+    padding: 8px;
+  }
+}
+
+.filter {
+  background-color: $button-color;
+  border-radius: 5px;
+  border: 1px solid $color-border;
+  color: $white;
+  font-size: 16px;
+  padding: 8px 12px;
+  transition: border-color 0.3s ease-in-out;
+  width: 120px;
+
+  &:focus {
+    border-color: $color-highlight;
+    outline: none;
+  }
+}
+
+.check {
+  appearance: none;
+  background-color: $color-background;
+  border-radius: 5px;
+  border: 1px solid $color-border;
+  color: $color-text;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 10px;
+  width: 160px;
+}
+
+.check:focus {
+  border-color: $color-highlight;
+  outline: none;
+}
+
+.check option {
+  font-size: 16px;
+  padding: 10px;
+}
+
+.check option:hover {
+  background-color: lighten($color-background, 10%);
 }

--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -1,43 +1,43 @@
+@import "./colors/variables.scss";
+
 .contramsg:hover {
-  background-color: #3c0364;
-} /*# sourceMappingURL=login.css.map */
+  background-color: $hover-pass;
+}
 
 .separation {
   margin: 20px 20px;
 }
 
 .contramsg {
-  background-color: #5100a2;
+  background-color: $back-pass;
+  border-color: $border-pass;
   border-radius: 5px;
-  border-color: #212529;
-  color: #ffffff;
+  color: $white;
   cursor: pointer;
   padding: 15px 35px;
   text-align: center;
-  text-decoration: none;
-  transition: background-color 0.3s ease;
 }
 
 .loginbtn {
-  background-color: #007bff;
-  border-color: #007bff;
+  background-color: $blue;
+  border-color: $blue;
   border-radius: 5px;
-  color: #ffffff;
+  color: $white;
   cursor: pointer;
   padding: 10px 20px;
-  transition: background-color 0.3s ease;
   text-decoration: none;
+  transition: background-color 0.3s ease;
 }
 .loginbtn:hover {
-  background-color: #0056b3;
+  background-color: $login-hover;
 }
 
 .registrarmsg {
-  background-color: #259503;
-  border-color: #ffffff;
+  background-color: $reg-back;
+  border-color: $white;
   border-radius: 5px;
   border-radius: 5px;
-  color: #ffffff;
+  color: $white;
   cursor: pointer;
   padding: 15px 35px;
   text-align: center;
@@ -45,5 +45,5 @@
   transition: background-color 0.3s ease;
 }
 .registrarmsg:hover {
-  background-color: #046f00;
+  background-color: $hover-reg;
 }

--- a/app/assets/stylesheets/passwordc.scss
+++ b/app/assets/stylesheets/passwordc.scss
@@ -1,8 +1,10 @@
+@import "./colors/variables.scss";
+
 .pasbtn {
-  background-color: #b8a901;
-  border-color: #ffffff;
+  background-color: $pasbtn;
+  border-color: $white;
   border-radius: 5px;
-  color: #ffffff;
+  color: $white;
   cursor: pointer;
   padding: 7px 18px;
   text-align: center;

--- a/app/assets/stylesheets/register.scss
+++ b/app/assets/stylesheets/register.scss
@@ -1,22 +1,24 @@
+@import "./colors/variables.scss";
+
 .loginbtnr {
-  background-color: #007bff;
-  border-color: #007bff;
+  background-color: $blue;
+  border-color: $blue;
   border-radius: 5px;
-  color: #ffffff;
+  color: $white;
   cursor: pointer;
   padding: 10px 20px;
   text-decoration: none;
   transition: background-color 0.3s ease;
 }
 .loginbtnr:hover {
-  background-color: #0056b3;
+  background-color: $hoverbtn;
 }
 
 .registrarmsgr {
-  background-color: #259503;
-  border-color: #ffffff;
+  background-color: $backgorund-btn;
+  border-color: $white;
   border-radius: 5px;
-  color: #ffffff;
+  color: $white;
   cursor: pointer;
   padding: 8px 24px;
   text-align: center;
@@ -24,5 +26,5 @@
   transition: background-color 0.3s ease;
 }
 .registrarmsgr:hover {
-  background-color: #046f00;
+  background-color: $backhover-btn;
 }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -69,7 +69,7 @@ class EventsController < ApplicationController
     redirect_to events_index_path
   end
 
-  def destroy_foto
+  def destroy_photo
     @event = Event.find(params[:id])
     @event.foto.destroy
     redirect_back fallback_location: events_index_path, notice: 'succes'

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,11 +21,35 @@ class EventsController < ApplicationController
   end
 
   def index
-    @event = Event.user_event(current_user)
+    @date = params[:fecha]
+    @private = params[:privado]
+
+    filter
+    filer_private
+  end
+
+  def filter
+    if @date
+      @event = Event.user_event(current_user).where(fecha: @date)
+      @date = ''
+    else
+      @event = Event.user_event(current_user)
+    end
+  end
+
+  def filer_private
+    @event = Event.user_event(current_user).where(privado: @private) if @private
+    @private = ''
   end
 
   def public
-    @event = Event.where(privado: false)
+    @date = params[:fecha]
+    if @date
+      @event = Event.where(fecha: @date, privado: false)
+      @date = ''
+    else
+      @event = Event.where(privado: false)
+    end
   end
 
   def edit

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,19 +1,30 @@
+<div class="search">
+    <form>
+      <%= date_field :fecha, @date, class: 'field',required: true %>
+      <%= submit_tag "Filtrar Fecha", class: "filter" %>
+    </form>
+    <form>
+      <%= select_tag(:privado, options_for_select([['Privado', true], ['Publico', false]]), class: 'check') %>
+      <%= submit_tag "Filtrar Tipo", class: "filter" %>
+    </form>
+      <%= link_to 'Reiniciar', events_index_path, class: "filter" %>
+  </div>
 <div style="width: 1000px; margin-top: 100px; max-height: 700px; overflow-y: auto; margin-left: 23%;">
   <div class="d-flex flex-wrap justify-content-between">
     <% @event.each do |event| %>
     <div class="mr-3 mb-3" style="width: calc(33.33% - 1rem); max-width: calc(33.33% - 1rem);">
       <div class="card h-100" style="width: 100%; border-radius: 15px; border: 1px solid #E0E0E0; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);">
-          <td><%= image_tag event.foto if event.foto.attached? %></td>
+          <h5 class="card-title"><%= event.id %>._ <%= event.titulo %></h5>
+          <img>
           <% if event.foto.attached? %>
+            <%= image_tag event.foto%>
             <%= link_to 'Eliminar Foto', destroy_foto_event_path(event), method: :delete, data: { confirm: '¿Estás seguro de que quieres eliminar esta foto?' } %>
           <% else %>
             <%= 'No hay foto de este evento' %>
           <% end %>
-        <div class="card-body">
-          <h5 class="card-title"><%= event.id %>._ <%= event.titulo %></h5>
-          <p class="card-text"><%= event.descripcion %></p>
-        </div>
+        </img>
         <ul class="list-group list-group-flush">
+          <li class="list-group-item"><%= event.descripcion %></li>
           <li class="list-group-item"> Fecha: <%= event.fecha %></li>
           <li class="list-group-item"><%= event.ubicacion.gsub(".", "<br>").html_safe %></li>
           <li class="list-group-item"> Costo: <%= event.costo %> Privado: <%= event.privado ? 'Si' : 'No' %></li>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,28 +1,13 @@
-<div class="search">
-    <form>
-      <%= date_field :fecha, @date, class: 'field',required: true %>
-      <%= submit_tag "Filtrar Fecha", class: "filter" %>
-    </form>
-    <form>
-      <%= select_tag(:privado, options_for_select([['Privado', true], ['Publico', false]]), class: 'check') %>
-      <%= submit_tag "Filtrar Tipo", class: "filter" %>
-    </form>
-      <%= link_to 'Reiniciar', events_index_path, class: "filter" %>
-  </div>
 <div style="width: 1000px; margin-top: 100px; max-height: 700px; overflow-y: auto; margin-left: 23%;">
   <div class="d-flex flex-wrap justify-content-between">
     <% @event.each do |event| %>
     <div class="mr-3 mb-3" style="width: calc(33.33% - 1rem); max-width: calc(33.33% - 1rem);">
       <div class="card h-100" style="width: 100%; border-radius: 15px; border: 1px solid #E0E0E0; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);">
           <h5 class="card-title"><%= event.id %>._ <%= event.titulo %></h5>
-          <img>
-          <% if event.foto.attached? %>
-            <%= image_tag event.foto%>
-            <%= link_to 'Eliminar Foto', destroy_foto_event_path(event), method: :delete, data: { confirm: '¿Estás seguro de que quieres eliminar esta foto?' } %>
-          <% else %>
-            <%= 'No hay foto de este evento' %>
-          <% end %>
-        </img>
+          <%= event.foto.attached? ? 
+            (image_tag event.foto) +
+            (link_to 'Eliminar Foto', destroy_photo_event_path(event), class: 'delete-photo', method: :delete, data: { confirm: '¿Estás seguro de que quieres eliminar esta foto?' }) :
+            ('No hay foto de este evento') %>
         <ul class="list-group list-group-flush">
           <li class="list-group-item"><%= event.descripcion %></li>
           <li class="list-group-item"> Fecha: <%= event.fecha %></li>

--- a/app/views/events/public.html.erb
+++ b/app/views/events/public.html.erb
@@ -3,13 +3,20 @@
     <% @event.each do |event| %>
     <div class="mr-3 mb-3" style="width: calc(33.33% - 1rem); max-width: calc(33.33% - 1rem);">
       <div class="card h-100" style="width: 100%; border-radius: 15px; border: 1px solid #E0E0E0; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);">
-            <td><%= image_tag event.foto if event.foto.attached? %></td>
-        <div class="card-body">
-          <h5 class="card-title"> Dueño: <%= event.user.name %><%= image_tag "icons/user.svg" %></h5>
-          <h5 class="card-title"> Titulo: <%= event.titulo %><%= image_tag "icons/title.svg" %></h5>
-          <p class="card-text"><%= image_tag "icons/description.svg" %> Descripción: <%= event.descripcion %></p>
-        </div>
+            <div class="card-body">
+              <h5 class="card-title"> Dueño: <%= event.user.name %><%= image_tag "icons/user.svg" %></h5>
+              <h5 class="card-title"> Titulo: <%= event.titulo %><%= image_tag "icons/title.svg" %></h5>
+            </div>
+            <img>
+              <% if event.foto.attached? %>
+                <%= image_tag event.foto%>
+                <%= link_to 'Eliminar Foto', destroy_foto_event_path(event), method: :delete, data: { confirm: '¿Estás seguro de que quieres eliminar esta foto?' } %>
+              <% else %>
+                <%= 'No hay foto de este evento' %>
+              <% end %>
+            </img>
         <ul class="list-group list-group-flush">
+          <li class="list-group-item"><%= image_tag "icons/description.svg" %> Descripción: <%= event.descripcion %></li>
           <li class="list-group-item"> <%= image_tag "icons/date.svg" %> Fecha: <%= event.fecha %></li>
           <li class="list-group-item"><%= image_tag "icons/location.svg" %> <%= event.ubicacion.gsub(".", "<br>").html_safe %></li>
           <li class="list-group-item"> Costo: <%= image_tag "icons/price.svg" %><%= event.costo %> </li>

--- a/app/views/events/public.html.erb
+++ b/app/views/events/public.html.erb
@@ -7,14 +7,7 @@
               <h5 class="card-title"> Dueño: <%= event.user.name %><%= image_tag "icons/user.svg" %></h5>
               <h5 class="card-title"> Titulo: <%= event.titulo %><%= image_tag "icons/title.svg" %></h5>
             </div>
-            <img>
-              <% if event.foto.attached? %>
-                <%= image_tag event.foto%>
-                <%= link_to 'Eliminar Foto', destroy_foto_event_path(event), method: :delete, data: { confirm: '¿Estás seguro de que quieres eliminar esta foto?' } %>
-              <% else %>
-                <%= 'No hay foto de este evento' %>
-              <% end %>
-            </img>
+              <%= event.foto.attached? ? (image_tag event.foto) : ('No hay foto de este evento') %>
         <ul class="list-group list-group-flush">
           <li class="list-group-item"><%= image_tag "icons/description.svg" %> Descripción: <%= event.descripcion %></li>
           <li class="list-group-item"> <%= image_tag "icons/date.svg" %> Fecha: <%= event.fecha %></li>

--- a/app/views/layouts/_filter.html.erb
+++ b/app/views/layouts/_filter.html.erb
@@ -9,12 +9,10 @@
       <% if signed_in? && current_page?(events_index_path)%>
         <%= select_tag(:privado, options_for_select([['Privado', true], ['Publico', false]]), class: 'check') %>
         <%= submit_tag "Filtrar Tipo", class: "filter" %>
+        <%= link_to 'Reiniciar', events_index_path, class: "filter" %>
       <% end %>
 
     </form>
-      <% if signed_in? && current_page?(events_index_path)%>
-        <%= link_to 'Reiniciar', events_index_path, class: "filter" %>
-      <% end %>
       <% if signed_in? && current_page?(events_public_path)%>
         <%= link_to 'Reiniciar', events_public_path, class: "filter" %>
       <% end %>

--- a/app/views/layouts/_filter.html.erb
+++ b/app/views/layouts/_filter.html.erb
@@ -1,0 +1,21 @@
+<div class="search">
+    <form>
+      <% if signed_in? && (current_page?(events_index_path) || current_page?(events_public_path))%>
+        <%= date_field :fecha, @date, class: 'field',required: true %>
+        <%= submit_tag "Filtrar Fecha", class: "filter" %>
+      <% end %>
+    </form>
+    <form>
+      <% if signed_in? && current_page?(events_index_path)%>
+        <%= select_tag(:privado, options_for_select([['Privado', true], ['Publico', false]]), class: 'check') %>
+        <%= submit_tag "Filtrar Tipo", class: "filter" %>
+      <% end %>
+
+    </form>
+      <% if signed_in? && current_page?(events_index_path)%>
+        <%= link_to 'Reiniciar', events_index_path, class: "filter" %>
+      <% end %>
+      <% if signed_in? && current_page?(events_public_path)%>
+        <%= link_to 'Reiniciar', events_public_path, class: "filter" %>
+      <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
 
   <body>
     <%= render 'layouts/navbar' %>
+    <%= render 'layouts/filter' %>
     
     <%= yield %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
+
   post '/events/:id',  to: 'events#destroy'
 
   get '/events/index', to: 'events#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,11 +23,11 @@ Rails.application.routes.draw do
 
   get '/key/show', to: 'key#show'
 
-  get '/events/:id/destroy_foto', to: 'events#destroy_foto'
+  get '/events/:id/destroy_photo', to: 'events#destroy_photo'
 
   resources :events do
     member do
-      delete :destroy_foto
+      delete :destroy_photo
     end
   end
 


### PR DESCRIPTION
## Quick Info

Improve two options to filter user events (by date or type), this in my events but if you go to Public Events that other users had created you also have a filter option but just by date because all are publics
There is a button to reset the info

## What does this change?
User Experience to get an event faster improving filters

## Why are you changing that?
Because its a better way to get an event, more comfortable and get a better user experience

## How do you manually test this?
Searching events using my filters options.  In my events and also in public events

## Screenshots 
# FIlter Options
![filters](https://github.com/BrightCoders-Institute/s5a1-administrador-de-eventos-team4/assets/86389712/61b708fd-7022-438e-bab1-00ba5788dc5c)
# Result searched by public event
![result_Dos](https://github.com/BrightCoders-Institute/s5a1-administrador-de-eventos-team4/assets/86389712/a3965b9f-2bed-4a31-84e0-12dbf11c607d)
# Result searched by date
![result](https://github.com/BrightCoders-Institute/s5a1-administrador-de-eventos-team4/assets/86389712/6b5f5fd7-9601-4c57-b45e-5207143100d5)
# Public Events FIlter
![public_events_filter](https://github.com/BrightCoders-Institute/s5a1-administrador-de-eventos-team4/assets/86389712/1230c980-6bbe-4bfb-9b4f-2d30df2d26a1)
